### PR TITLE
Conditionally replace by HTTPS scheme

### DIFF
--- a/nagato.py
+++ b/nagato.py
@@ -101,9 +101,9 @@ class HttpStream:
         if tunnel:
             self.writer.write(status_line)
 
-        version, status, reason = status_line.decode().split(' ')
+        version, status, reason = status_line.decode().split(' ', 2)
         reason = reason.rstrip('\r\n')
-        return version, status, reason
+        return version, int(status), reason
 
     @asyncio.coroutine
     def next_header_field(self, tunnel=False):
@@ -179,7 +179,8 @@ class HttpStream:
             n = self.chunk_len
 
         while n > 0:
-            buf = yield from self.reader.read(65536)
+            rlen = 65536 if n > 65536 else n
+            buf = yield from self.reader.read(rlen)
             n -= len(buf)
             self.writer.write(buf)
 


### PR DESCRIPTION
Separated from #4.

Quick summary of how this works:
1. Replace by HTTPS scheme.
2. If failed, don't replace scheme and fallback to the dummy header method.
3. Remember the choice for the host.

The downside of this is that the first request made by the user for each host
* should not have been errorneous. Otherwise `nagato` always fallbacks to the dummy header method. It would work, anyway.
* is repeated if failed and the response from the server is ignored. This might be problematic if the request was not idempotent.

Consideration:
* It turned out it was not Cloudflare's fault. It's up to server when it receives an HTTP request of which the scheme of the absolute URL is `https`. The outcome may be one of `200 OK` (ignoring the scheme), `302 Found` (redirecting to the HTTPS protocol), `400 Bad Request` (unexpected scheme), `404 Not Found` (somehow routed to a non-existent resource), `502 Bad Gateway` (or `521 Origin Down` by Cloudflare due to misconfiguration).